### PR TITLE
ability to switch to the ibotta-gem

### DIFF
--- a/.github/workflows/test-scheduler-lock.yml
+++ b/.github/workflows/test-scheduler-lock.yml
@@ -40,7 +40,7 @@ jobs:
         resque-lock-timeout-version:
           - "latest"
           - "https://github.com/Ibotta/resque-lock-timeout.git@v0.5.0-ibotta"
-          - "ibotta-resque-lock-timeout:https://github.com/Ibotta/resque-lock-timeout.git@v0.5.1"
+          - "ibotta-resque-lock-timeout;https://github.com/Ibotta/resque-lock-timeout.git@v0.5.1"
         exclude:
           # resque-scheduler (= 4.3.0) depends on redis (~> 3.3)
           - redis-version: "~> 4.8"

--- a/.github/workflows/test-scheduler-lock.yml
+++ b/.github/workflows/test-scheduler-lock.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [$default-branch]
   pull_request:
+  workflow_dispatch:
 jobs:
   test-scheduler-lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-scheduler-lock.yml
+++ b/.github/workflows/test-scheduler-lock.yml
@@ -40,7 +40,7 @@ jobs:
         resque-lock-timeout-version:
           - "latest"
           - "https://github.com/Ibotta/resque-lock-timeout.git@v0.5.0-ibotta"
-          - "https://github.com/Ibotta/resque-lock-timeout.git@tests-with-scheduler"
+          - "ibotta-resque-lock-timeout:https://github.com/Ibotta/resque-lock-timeout.git@v0.5.1"
         exclude:
           # resque-scheduler (= 4.3.0) depends on redis (~> 3.3)
           - redis-version: "~> 4.8"

--- a/scheduler-lock/Gemfile
+++ b/scheduler-lock/Gemfile
@@ -38,7 +38,7 @@ else
 end
 
 resque_lock_timeout_version = ENV.fetch("RESQUE_LOCK_TIMEOUT_VERSION", "latest")
-capture_resque_lock_timeout = resque_lock_timeout_version.split(":", 2)
+capture_resque_lock_timeout = resque_lock_timeout_version.split(";", 2)
 resque_lock_timeout_gem = if capture_resque_lock_timeout[1]
   resque_lock_timeout_version = capture_resque_lock_timeout[1]
   capture_resque_lock_timeout[0]

--- a/scheduler-lock/Gemfile
+++ b/scheduler-lock/Gemfile
@@ -37,17 +37,28 @@ else
   gem "resque-scheduler", *versions
 end
 
-case resque_lock_timeout_version = ENV.fetch("RESQUE_LOCK_TIMEOUT_VERSION", "latest")
+resque_lock_timeout_version = ENV.fetch("RESQUE_LOCK_TIMEOUT_VERSION", "latest")
+capture_resque_lock_timeout = resque_lock_timeout_version.split(":", 2)
+resque_lock_timeout_gem = if capture_resque_lock_timeout[1]
+  resque_lock_timeout_version = capture_resque_lock_timeout[1]
+  capture_resque_lock_timeout[0]
+else
+  "resque-lock-timeout"
+end
+puts "resque_lock_timeout_gem: #{resque_lock_timeout_gem}"
+puts "resque_lock_timeout_version: #{resque_lock_timeout_version}"
+
+case resque_lock_timeout_version
 when "master"
-  gem "resque-lock-timeout", git: "https://github.com/Ibotta/resque-lock-timeout.git"
+  gem resque_lock_timeout_gem, git: "https://github.com/Ibotta/resque-lock-timeout.git"
 when /^git:/, /^https:/
   repo, ref = resque_lock_timeout_version.split("@", 2)
-  gem "resque-lock-timeout", git: repo, ref: ref
+  gem resque_lock_timeout_gem, git: repo, ref: ref
 when "latest"
-  gem "resque-lock-timeout"
+  gem resque_lock_timeout_gem
 else
   versions = resque_lock_timeout_version.split(",")
-  gem "resque-lock-timeout", *versions
+  gem resque_lock_timeout_gem, *versions
 end
 
 gem "rake"


### PR DESCRIPTION
Adds the ability to add different gem names to the test matrix, so we can test against the newly named `ibotta-resque-lock-timeout` 